### PR TITLE
Fixed directory detection on IE11

### DIFF
--- a/batch.js
+++ b/batch.js
@@ -74,7 +74,7 @@ Batch.prototype._detectDirectories = function(callback) {
         }
         try {
             var reader = new FileReader();
-            reader.readAsBinaryString(file);
+            reader.readAsArrayBuffer(file);
             reader.onloadend = function(e) {
                 var error = reader.error;
                 var hadError = error && (


### PR DESCRIPTION
This is to fix the following issue on IE11:

- Drag a small file from Windows Explorer onto the workspace file tree.
- Or, go to File..Upload Local Files.
- Click the button labeled Select files to upload.
- Choose a small file.

Expected: the file is uploaded.
Actual: an error appears: Folder uploads are currently only supported by Google Chrome.

`FileReader.readAsBinaryString` was being used to detect whether a dropped item is a file or a directory. This method is not present on IE11, but `FileReader.readAsArrayBuffer` is present and serves the same purpose (either it successfully reads a file, or it fails to read a directory).

Note that this defect only occurs for files smaller than 17Kb, because `_detectDirectories` also includes a test on the file size.
